### PR TITLE
bug fixed: Missing application icon

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,6 @@
 {
     "win": {
+        "icon": "public/app.ico",
         "target": [
             "nsis",
             "portable"


### PR DESCRIPTION
## Description

Add icon to electron-builder.json.
( [https://www.electron.build/configuration/win](https://www.electron.build/configuration/win) )

## Motivation and Context

### Build warning

Missing application icon.

![2021-08-01_152136](https://user-images.githubusercontent.com/13682994/127763768-a172d2c0-4de4-4c6f-b5dc-9e569a5d37da.png)

### Wrong icon

Got electron default icon.

![2021-08-01_154519](https://user-images.githubusercontent.com/13682994/127763776-3bb9a91c-f911-49ac-a486-40103db29f9f.png)


## PR Screenshots 

### Output folder

![2021-08-01_152311](https://user-images.githubusercontent.com/13682994/127763930-26d39111-2ca9-42c7-951d-d1cf4d24b1e7.png)


### Windows icon

![2021-08-01_160021](https://user-images.githubusercontent.com/13682994/127763939-8f69f431-db56-41ad-906e-7e7246632254.png)

